### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/_episodes_rmd/01-introduction.Rmd
+++ b/_episodes_rmd/01-introduction.Rmd
@@ -309,7 +309,7 @@ working directory is the first step to analyzing your data.
 > that has a different directory structure? The top-level path in a Unix file
 > system is root `/`, but on Windows it is likely `C:\`. This is one of several
 > ways you might cause a script to break because a file path is configured
-> differently than your script anticipates. R packages like [here](https://cran.r-project.org/web/packages/here/index.html)
+> differently than your script anticipates. R packages like [here](https://cran.r-project.org/package=here)
 > and [file.path](https://www.rdocumentation.org/packages/base/versions/3.4.3/topics/file.path)
 > allow you to specify file paths is a way that is more operating system
 > independent. See Jenny Bryan's [blog post](https://www.tidyverse.org/articles/2017/12/workflow-vs-script/) for this

--- a/_episodes_rmd/04-dplyr.Rmd
+++ b/_episodes_rmd/04-dplyr.Rmd
@@ -33,7 +33,7 @@ variants <- read.csv("https://ndownloader.figshare.com/files/14632895")
 
 Bracket subsetting is handy, but it can be cumbersome and difficult to read, especially for complicated operations. 
 
-Luckily, the [`dplyr`](https://cran.r-project.org/web/packages/dplyr/dplyr.pdf)
+Luckily, the [`dplyr`](https://cran.r-project.org/package=dplyr
 package provides a number of very useful functions for manipulating dataframes
 in a way that will reduce repetition, reduce the probability of making
 errors, and probably even save you some typing. As an added bonus, you might


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.