### PR TITLE
Changing ggplot jitter use and adding boxplots

### DIFF
--- a/_episodes_rmd/05-data-visualization.Rmd
+++ b/_episodes_rmd/05-data-visualization.Rmd
@@ -188,7 +188,7 @@ ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
 
 ## More geoms and colors
 
-Let's see try changing the geom and create a boxplot to see that the colors will be still determined by **`sample_id`**.
+Let's try changing the geom and create a boxplot to see that the colors will be still determined by **`sample_id`**.
 This time we'll use the sample_id for the x axis as well since this makes more sense for a boxplot.
 
 ```{r color-by-sample-boxplot, purl=FALSE}
@@ -197,6 +197,8 @@ ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 ```
 
 We can also add multiple geoms to the same plot.  Let's add `geom_jitter` into this plot as well.
+`geom_jitter` will plot points for each of the the depth values like `geom_point`
+but it will add a bit of randomness so they won't be plotted on top of one another.
 
 
 ```{r box-and-jitter, purl=FALSE}
@@ -208,7 +210,7 @@ ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 > ## Challenge
 >
 > In the last plot the jitter for one of the samples covers up the box plot
-> Use what you just learned to a boxplot with jitter of depth (`DP`) by
+> Use what you just learned to create a boxplot with jitter of depth (`DP`) by
 > sample (`sample_id`) with the samples showing in different colors where the jitter is more transparent.
 > Bonus:  Change only the boxplots to be black.
 >
@@ -238,8 +240,8 @@ ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 > >   geom_jitter() +
 > >   geom_boxplot()
 > > ```
-> > Order makes a difference in ggplot so the jitter geom is plotted first and then
-> > the boxplot geom is plotted on top of the jitter.
+> > Order makes a difference in ggplot so when we switch the geom order the jitter geom
+> > is plotted first and then the boxplot geom is plotted on top of the jitter.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes_rmd/05-data-visualization.Rmd
+++ b/_episodes_rmd/05-data-visualization.Rmd
@@ -233,7 +233,7 @@ ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 > What happens when we switch around the layers from our last plot?
 >
 > > ## Solution
-> > ```{r jitter-challenge, purl=FALSE}
+> > ```{r jitter-challenge3, purl=FALSE}
 > >  ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 > >   geom_jitter() +
 > >   geom_boxplot()

--- a/_episodes_rmd/05-data-visualization.Rmd
+++ b/_episodes_rmd/05-data-visualization.Rmd
@@ -160,18 +160,12 @@ ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
   geom_point(alpha = 0.5)
 ```
 
-Notice that we can change the geom layer and colors will be still determined by **`sample_id`**
-
-```{r color-by-sample-2, purl=FALSE}
-ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
-  geom_jitter(alpha = 0.5)
-```
 
 To make our plot more readable, we can add axis labels:
 
 ```{r add-axis-labels, purl=FALSE}
 ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
-  geom_jitter(alpha = 0.5) +
+  geom_point(alpha = 0.5) +
   labs(x = "Base Pair Position",
        y = "Read Depth (DP)")
 ```
@@ -191,6 +185,48 @@ ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
 > > ```
 > {: .solution}
 {: .challenge}
+
+## More geoms and colors
+
+Let's see try changing the geom and create a boxplot to see that the colors will be still determined by **`sample_id`**.
+This time we'll use the sample_id for the x axis as well since this makes more sense for a boxplot.
+
+```{r color-by-sample-boxplot, purl=FALSE}
+ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
+  geom_boxplot()
+```
+
+We can also add multiple geoms to the same plot.  Let's add `geom_jitter` into this plot as well.
+
+
+```{r box-and-jitter, purl=FALSE}
+ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
+  geom_boxplot() +
+  geom_jitter()
+```
+
+> ## Challenge
+>
+> In the last plot the jitter for one of the samples covers up the box plot
+> Use what you just learned to a boxplot with jitter of depth (`DP`) by
+> sample (`sample_id`) with the samples showing in different colors where the jitter is more transparent.
+> Bonus:  Change only the boxplots to be black.
+>
+> > ## Solution
+> > ```{r jitter-challenge, purl=FALSE}
+> >  ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
+> >   geom_boxplot() +
+> >   geom_jitter(alpha=0.5)
+> > ```
+> > Bonus answer
+> > ```{r jitter-challenge2, purl=FALSE}
+> >  ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
+> >   geom_boxplot(color="black") +
+> >   geom_jitter(alpha=0.5)
+> > ```
+> {: .solution}
+{: .challenge}
+
 
 ## Faceting
 

--- a/_episodes_rmd/05-data-visualization.Rmd
+++ b/_episodes_rmd/05-data-visualization.Rmd
@@ -224,6 +224,22 @@ ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
 > >   geom_boxplot(color="black") +
 > >   geom_jitter(alpha=0.5)
 > > ```
+> > Color and other settings specified in the geom overrides the color specified in ggplot call.
+> {: .solution}
+{: .challenge}
+
+> ## Challenge
+>
+> What happens when we switch around the layers from our last plot?
+>
+> > ## Solution
+> > ```{r jitter-challenge, purl=FALSE}
+> >  ggplot(data = variants, aes(x = sample_id, y = DP, color = sample_id)) +
+> >   geom_jitter() +
+> >   geom_boxplot()
+> > ```
+> > Order makes a difference in ggplot so the jitter geom is plotted first and then
+> > the boxplot geom is plotted on top of the jitter.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Been feeling like the use of jitter in the coverage plot doesn't quite make sense since you wouldn't want to jitter when the position values are important.  I also wanted to add in the use of boxplot so you can show layering different geoms.  I put the two together here where I...

- removed the use of jitter in the coverage plot
- added in using a boxplot and jitter
- added in two short challenges with jitter and boxplot