### PR TITLE
Tip: install R and RStudio locally anyway.

### DIFF
--- a/_episodes_rmd/01-introduction.Rmd
+++ b/_episodes_rmd/01-introduction.Rmd
@@ -36,16 +36,15 @@ knitr_fig_path("01-")
 In this lesson we will take you through the very first things you need to get
 R working.
 
-> ## Tip: This lesson works best on the cloud
+> ## Tip: Install R and RStudio locally anyway
 >
 > Remember, these lessons assume we are using the pre-configured virtual machine
-> instances provided to you at a genomics workshop. Much of this work could be
-> done on your laptop, but we use instances to simplify workshop setup
-> requirements, and to get you familiar with using the cloud (a common
-> requirement for working with big data).
-> Visit the [Genomics Workshop setup page](http://www.datacarpentry.org/genomics-workshop/setup.html)
-> for details on getting this instance running on your own, or for the info you
-> need to do this on your own computer.
+> instances provided to you at a genomics workshop, running an RStudio server. 
+> This simplifies installation and running of the workshop - but servers can go down 
+> during workshops. As a backup plan, if you are using your own computer for this workshop, 
+> please install a local copy of both R and RStudio, see instructions at the
+> [R ecology lesson setup page](https://datacarpentry.org/R-ecology-lesson/#install-r-and-rstudio)
+> After the workshop, this enables you to keep analysing data on your local computer.
 {: .callout}
 
 


### PR DESCRIPTION
In `01-introduction.Rmd`, "Tip: This Lesson works better in the cloud" gave information for running the genomics workshop command line VMs, not for the RStudio Server that `genomics-r-intro` actually uses. So, I've proposed changes to this that link instead to the R ecology lesson setup page, and encourage learners to install R and RStudio locally. In workshops that we have had in Edinburgh, there have been instances of a (local) server going down so we cannot continue using studio servers. If my proposed solution is not appropriate, the tip should anyway be updated to be specific to an RStudio Server lesson.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
