### PR TITLE
Update 04-bioconductor-vcfr.Rmd

### DIFF
--- a/_episodes_rmd/04-bioconductor-vcfr.Rmd
+++ b/_episodes_rmd/04-bioconductor-vcfr.Rmd
@@ -80,7 +80,7 @@ You may need to also allow it to install some dependencies or update installed p
 
 While we are only focusing in this workshop on VCF analyses, there are hundreds or thousands of different types of data and analyses that bioinformaticians may want to work with. Sometimes you may get a new dataset and not know exactly where to start with analyzing or visualizing it. The Bioconductor package search view can be a great way to browse through the packages that are available.
 
-![screenshot of bioconductor search](fig/bioconductor_search.jpg)
+![screenshot of bioconductor search](../fig/bioconductor_search.jpg)
 
 > ## Tip: Searching for packages on the Bioconductor website
 >


### PR DESCRIPTION
updates the path to a figure that isn't rendering. 

if this doesn't work, perhaps using `<img src="../fig/bioconductor_search.jpg" alt="screenshot of bioconductor search="width:1000px;"/>` will work.