### PR TITLE
Fix knitr_fig_path prefix for reordered files (part of #151)

### DIFF
--- a/_episodes_rmd/00-introduction.Rmd
+++ b/_episodes_rmd/00-introduction.Rmd
@@ -28,7 +28,7 @@ source: Rmd
 
 ```{r, include = FALSE}
 source("../bin/chunk-options.R")
-knitr_fig_path("01-")
+knitr_fig_path("00-")
 ```
 
 ## Getting ready to use R for the first time

--- a/_episodes_rmd/01-r-basics.Rmd
+++ b/_episodes_rmd/01-r-basics.Rmd
@@ -28,7 +28,7 @@ source: Rmd
 
 ```{r, include = FALSE}
 source("../bin/chunk-options.R")
-knitr_fig_path("02-")
+knitr_fig_path("01-")
 ```
 
 ## "The fantastic world of R awaits you" OR "Nobody wants to learn how to use R"

--- a/_episodes_rmd/02-data-prelude.Rmd
+++ b/_episodes_rmd/02-data-prelude.Rmd
@@ -18,7 +18,7 @@ source: Rmd
 
 ```{r, include = FALSE}
 source("../bin/chunk-options.R")
-knitr_fig_path("01-")
+knitr_fig_path("02-")
 ```
 
 ## Preface

--- a/_episodes_rmd/04-bioconductor-vcfr.Rmd
+++ b/_episodes_rmd/04-bioconductor-vcfr.Rmd
@@ -18,8 +18,6 @@ source: Rmd
 
 ```{r chunk_options, include=FALSE}
 source("../bin/chunk-options.R")
-
-# TODO: This needs to be updated when the episode number is finalized
 knitr_fig_path("04-")
 ```
 


### PR DESCRIPTION
Forgot to update the fig path in the files after renaming.