### PR TITLE
urgent: fix workflows

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -127,7 +127,7 @@ jobs:
         id: check-rmd
         working-directory: lesson
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -131,9 +131,10 @@ jobs:
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,9 +48,10 @@ jobs:
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Look for R-markdown files
         id: check-rmd
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
This pull request updates the workflows for this lesson.

There are two items that are changed:

1. r-lib/actions/setup-r now uses `@v2` instead of `@master` as the default tag
2. the `set-output` GHA workflow command has been updated as it was deprecated.

see https://github.com/carpentries/styles/issues/641 for details

If you have any questions, contact @zkamvar