### PR TITLE
CONTRIBUTING.md to main branch, not gh-pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,20 +109,20 @@ The maintainers are community volunteers and have final say over what gets merge
 To use the web interface for contributing to a lesson:
 
 1.  Fork the master repository to your GitHub profile.
-2.  Within your version of the forked repository, move to the `gh-pages` branch and
+2.  Within your version of the forked repository, make sure you are in the `main` branch and
 create a new branch for each significant change being made.
 3.  Navigate to the file(s) you wish to change within the new branches and make revisions as required.
 4.  Commit all changed files within the appropriate branches.
 5.  Create individual pull requests from each of your changed branches
-to the `gh-pages` branch within the master repository.
+to the `main` branch within the master repository.
 6.  If you receive feedback, make changes using your issue-specific branches of the forked
 repository and the pull requests will update automatically.
 7.  Repeat as needed until all feedback has been addressed.
 
-When starting work, please make sure your clone of the master `gh-pages` branch is up-to-date
+When starting work, please make sure your clone of the master `main` branch is up-to-date
 before creating your own revision-specific branch(es) from there.
 Additionally, please only work from your newly-created branch(es) and *not*
-your clone of the master `gh-pages` branch.
+your clone of the master `main` branch.
 Lastly, published copies of all the lessons are available in the `gh-pages` branch of the master
 repository for reference while revising.
 


### PR DESCRIPTION
Just a quick change in CONTRIBUTING.md to match the main README's instructions to make pull requests into `main`, not `gh-pages`. 