### PR TITLE
tip-box-install-tinytex

### DIFF
--- a/_episodes_rmd/07-knitr-markdown.Rmd
+++ b/_episodes_rmd/07-knitr-markdown.Rmd
@@ -376,9 +376,12 @@ of the file.
 > Creating .pdf documents may require installation of some extra software. If
 > required this is detailed in an error message.
 >
-> Tex for windows is available [here](http://miktex.org/2.9/setup).
+> To install the required software to knit your report to a PDF, you can run the following code:
 >
-> Tex for mac is available [here](http://tug.org/mactex).
+> ```
+> install.packages('tinytex')
+> tinytex::install_tinytex()
+> ```
 {: .callout}
 
 


### PR DESCRIPTION
Changed tip box at the end of the knitr episode to include code to download R package tinytex instead of having students install MiKTeX or MacTeX