### PR TITLE
fix malformed solution block

### DIFF
--- a/_episodes_rmd/05-dplyr.Rmd
+++ b/_episodes_rmd/05-dplyr.Rmd
@@ -153,6 +153,7 @@ select(variants, ends_with("B"))
 >> variants_result <- select(variants_subset, -Indiv, -FILTER)
 >> variants_result
 >> ```
+> {: .solution}
 >
 > We can also get to `variants_result` in one line of code:
 >


### PR DESCRIPTION
This fixes the first solution block in episode 5. It was causing trouble with the transition (see https://github.com/carpentries/lesson-transition/issues/51)