### PR TITLE
Fix floating solution boxes

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -20,6 +20,14 @@ Machine Image (AMI). Please follow the instructions below to prepare your comput
 
 This lesson requires a working spreadsheet program. If you don't have a spreadsheet program already, you can use LibreOffice. It's a free, open source spreadsheet program.  Directions to install are included for each Windows, Mac OS X, and Linux systems below. For Windows, you will also need to install Git Bash, PuTTY, or the Ubuntu Subsystem.
 
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::  solution
 
 ## Windows
@@ -107,6 +115,14 @@ We have installed software using [miniconda](https://docs.conda.io/en/latest/min
 
 ### Miniconda3
 
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::  solution
 
 ## MacOS
@@ -124,6 +140,14 @@ Then, follow the instructions that you are prompted with on the screen to instal
 :::::::::::::::::::::::::
 
 ### FastQC
+
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::  solution
 
@@ -171,6 +195,14 @@ $ fastqc -h
 
 ### Trimmomatic
 
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::  solution
 
 ## MacOS
@@ -211,6 +243,14 @@ $ ls ~/src/Trimmomatic-0.38/adapters/
 $ java -jar ~/src/Trimmomatic-0.38/trimmomatic-0.38.jar
 ```
 
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::  solution
 
 ## Simplify the Invocation, or to Test your installation if you installed with miniconda3:
@@ -232,6 +272,14 @@ $ trimmomatic
 :::::::::::::::::::::::::
 
 ### BWA
+
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::  solution
 
@@ -264,6 +312,14 @@ $ bwa
 ```
 
 ### SAMtools
+
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::  solution
 
@@ -310,6 +366,14 @@ $ samtools
 ```
 
 ### BCFtools
+
+:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
+
+
+<!-- This div is intentionally empty to allow the solution to float alone-->
+
+
+::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::  solution
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -187,11 +187,12 @@ $ chmod +x ~/bin/fastqc
 
 **Test your installation by running:**
 
-:::::::::::::::::::::::::
-
 ```bash
 $ fastqc -h
 ```
+
+:::::::::::::::::::::::::
+
 
 ### Trimmomatic
 
@@ -237,11 +238,12 @@ $ ls ~/src/Trimmomatic-0.38/adapters/
 
 **Test your installation by running:** (assuming things are installed in ~/src)
 
-:::::::::::::::::::::::::
-
 ```bash
 $ java -jar ~/src/Trimmomatic-0.38/trimmomatic-0.38.jar
 ```
+
+:::::::::::::::::::::::::
+
 
 :::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
 
@@ -305,11 +307,12 @@ $ export PATH=~/src/bwa-0.7.17:$PATH
 
 **Test your installation by running:**
 
-:::::::::::::::::::::::::
-
 ```bash
 $ bwa
 ```
+
+:::::::::::::::::::::::::
+
 
 ### SAMtools
 
@@ -359,11 +362,12 @@ $ source ~/.bashrc
 
 **Test your installation by running:**
 
-:::::::::::::::::::::::::
-
 ```bash
 $ samtools
 ```
+
+:::::::::::::::::::::::::
+
 
 ### BCFtools
 
@@ -405,11 +409,12 @@ $ source ~/.bashrc
 
 **Test your installation by running:**
 
-:::::::::::::::::::::::::
-
 ```bash
 $ bcftools
 ```
+
+:::::::::::::::::::::::::
+
 
 ### IGV
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

#220 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

1. adds an empty div before each floating `solution`, to prevent the expandable boxes from obscuring other page content.
2. moves a few code blocks inside these solution boxes, as the infrastructure transition seems to have resulted in some code blocks getting stuck outside the div with the instructions they belong to.

_If any relevant discussions have taken place elsewhere, please provide links to these._

See https://github.com/carpentries/lesson-transition/issues/46#issuecomment-1522014660 for where this issue with the styling of solution blocks was first reported and discussed.