### PR TITLE
Update 01-r-basics.Rmd escaped or

### DIFF
--- a/episodes/01-r-basics.Rmd
+++ b/episodes/01-r-basics.Rmd
@@ -571,7 +571,7 @@ In the square brackets you place the name of the vector followed by the comparis
 | \==                  | exactly equal to                                                                                                                                                                                                                            |
 | !=                  | not equal to                                                                                                                                                                                                                                |
 | !x                  | not x                                                                                                                                                                                                                                       |
-| a | b               | a or b                                                                                                                                                                                                                                      |
+| a \| b               | a or b                                                                                                                                                                                                                                      |
 | a \& b               | a and b                                                                                                                                                                                                                                     |
 
 :::::::::::::::::::::::::::::::::::::::::  callout


### PR DESCRIPTION
escaped Or \| operator as wasn't rendering correctly

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
