### PR TITLE
Update 03-basics-factors-dataframes.Rmd

### DIFF
--- a/episodes/03-basics-factors-dataframes.Rmd
+++ b/episodes/03-basics-factors-dataframes.Rmd
@@ -618,11 +618,11 @@ snp_chromosomes_2
 ```
 
 Trouble can really start when we try to coerce a factor. For example, when we
-try to coerce the `sample_id` column in our data frame into a numeric mode
+try to coerce the `factor_snps` vector into a numeric mode
 look at the result:
 
 ```{r, purl=FALSE}
-as.numeric(variants$sample_id)
+as.numeric(factor_snps)
 ```
 
 Strangely, it works! Almost. Instead of giving an error message, R returns


### PR DESCRIPTION
If using R > 4.0 the sample_id will be a character so using the as.numeric will show NAs, using factor_snps vectopr for example instead

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
