### PR TITLE
Changing ggtitle function to use labs arg

### DIFF
--- a/episodes/06-data-visualization.Rmd
+++ b/episodes/06-data-visualization.Rmd
@@ -205,14 +205,14 @@ ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
        y = "Read Depth (DP)")
 ```
 
-To add a *main* title to the plot, we use [`ggtitle()`](https://ggplot2.tidyverse.org/reference/labs.html):
+To add a *main* title to the plot, we use [the title argument for the `labs()` function](https://ggplot2.tidyverse.org/reference/labs.html):
 
 ```{r add-main-title, purl=FALSE}
 ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
   geom_point(alpha = 0.5) +
   labs(x = "Base Pair Position",
-       y = "Read Depth (DP)") +
-  ggtitle("Read Depth vs. Position")
+       y = "Read Depth (DP)",
+       title = "Read Depth vs. Position")
 ```
 
 Now the figure is complete and ready to be exported and saved to a file. This can be achieved easily using [`ggsave()`](https://ggplot2.tidyverse.org/reference/ggsave.html), which can write, by default, the most recent generated figure into different formats (e.g., `jpeg`, `png`, `pdf`) according to the file extension. So, for example, to create a pdf version of the above figure with a dimension of $6\times4$ inches:
@@ -252,8 +252,8 @@ To further customize the plot, we can change the default font format:
 ggplot(data = variants, aes(x = POS, y = DP, color = sample_id)) +
   geom_point(alpha = 0.5) +
   labs(x = "Base Pair Position",
-       y = "Read Depth (DP)") +
-  ggtitle("Read Depth vs. Position") +
+       y = "Read Depth (DP)",
+       title = "Read Depth vs. Position") +
   theme(text = element_text(family = "Bookman"))
 ```
 


### PR DESCRIPTION
This consistently uses the `labs()` function's arguments instead of mixing `labs()` and `ggtitle()`

This was also changed in the r-socialsci lesson - https://github.com/datacarpentry/r-socialsci/issues/99
