### PR TITLE
added instructor notes to address #240

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -1,7 +1,19 @@
 ---
 title: Instructor Notes
+source: Rmd
 ---
 
-FIXME
+Please see the [Genomics Data Carpentry Instructor Notes](https://datacarpentry.github.io/cloud-genomics/instructor-notes.html).
 
+:::::::::::::::::::::::::::::::::::::::::  callout
 
+## Tip: Assigning instances to learners
+
+###
+
+We recommend using an online spreadsheet such as Google Sheets to assign learners their cloud
+instances, preferably by having a list of available IP addresses, and allowing users to 'claim'
+and instance by name. If possible, maintain 1 or 2 unclaimed instances in case some fail to
+launch or a learner encounters some unrecoverable error.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Added to the instructor notes. ALSO - I note that there is a weird bug in the rendering of the callout. If It didn't include a H3 heading in the tip box ('###') and accounting for line breaks, the paragraph under the callout title was also considered H2 when rendered. Maybe @zkamvar may have a look some day