### PR TITLE
Adjust lesson title

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@
 carpentry: 'dc'
 
 # Overall title for pages.
-title: 'Intro to R and RStudio for Genomics'
+title: 'Data Analysis and Visualization with R for Genomics'
 
 # Date the lesson was created (YYYY-MM-DD, this is empty by default)
 created: '2018-03-12'


### PR DESCRIPTION
Would you be willing to adjust the title of this lesson, to make it more consistent with the listing [on the Data Carpentry lessons page](https://datacarpentry.org/lessons/#genomics)? I would prefer to do it this way around -- as opposed to adjusting the listing on the DC website to match the lesson title here -- since I am generally in favour of lesson titles that describe the skills that the learner will gain from following the lesson.